### PR TITLE
 threejs removes dots from name, change to dash

### DIFF
--- a/src/cqparts/assembly.py
+++ b/src/cqparts/assembly.py
@@ -1,6 +1,7 @@
 
 import six
 import string
+import re
 
 from types import GeneratorType
 

--- a/src/cqparts/assembly.py
+++ b/src/cqparts/assembly.py
@@ -1,5 +1,6 @@
 
 import six
+import string
 
 from types import GeneratorType
 
@@ -12,6 +13,18 @@ from .errors import AssemblyFindError
 
 import logging
 log = logging.getLogger(__name__)
+
+
+# Component Name Validity, considering:
+#   - chosen delimiter, and
+#   - usage as filename
+VALID_NAME_CHARS = set(
+    string.ascii_letters + string.digits + # alphanumeric
+    '_()#@%^=+ '
+)
+# note: does not include
+#   `.` - threejs removes '.' from filenames, leading to incompatability (see PR #147)
+#   `-` - chosen delimiter
 
 
 class Assembly(Component):
@@ -158,9 +171,14 @@ class Assembly(Component):
                     "(must be a (str, Component))"
                 ) % (name, component))
 
-            # name cannot contain a '.'
-            if '.' in name:
-                raise ValueError("component names cannot contain a '.' (%s, %r)" % (name, component))
+            # check component name validity
+            invalid_chars = set(name) - VALID_NAME_CHARS
+            if invalid_chars:
+                raise ValueError(
+                    "component name {!r} invalid; cannot include {!r}".format(
+                        name, invalid_chars
+                    )
+                )
 
     @staticmethod
     def verify_constraints(constraints):

--- a/src/cqparts/assembly.py
+++ b/src/cqparts/assembly.py
@@ -325,7 +325,7 @@ class Assembly(Component):
         """
 
         if isinstance(keys, six.string_types):
-            keys = [k for k in keys.split('.') if k]
+            keys = re.split(r'[\.-]+', keys)
         if _index >= len(keys):
             return self
 

--- a/src/cqparts/codec/gltf.py
+++ b/src/cqparts/codec/gltf.py
@@ -407,13 +407,13 @@ class GLTFExporter(Exporter):
 
                 for (child_name, child) in obj.components.items():
                     # Full name of child (including '.' separated list of all parents)
-                    full_name = "%s.%s" % (name, child_name)
+                    full_name = "%s-%s" % (name, child_name)
 
                     # Recursively add children
                     add(
                         child,
-                        filename="%s.%s%s" % (split[0], child_name, split[1]),
-                        name="%s.%s" % (name, child_name),
+                        filename="%s-%s%s" % (split[0], child_name, split[1]),
+                        name="%s-%s" % (name, child_name),
                         origin=obj_world_coords,
                         parent_node_index=node_index,
                     )

--- a/tests/t_cqparts/test_assembly.py
+++ b/tests/t_cqparts/test_assembly.py
@@ -70,12 +70,23 @@ class BadAssemblyTests(CQPartsTest):
         with self.assertRaises(ValueError):
             A().components
 
-    def test_bad_component_keychar(self):
+    def test_bad_component_keychar_period(self):
         class A(cqparts.Assembly):
             def make_components(self):
                 yield {
                     'p': Box(),  # good key
-                    'a.b': Box(),  # key can't contain a '.'
+                    'a.b': Box(),  # key can't contain a '.' #147
+                }
+
+        with self.assertRaises(ValueError):
+            A().components
+
+    def test_bad_component_keychar_dash(self):
+        class A(cqparts.Assembly):
+            def make_components(self):
+                yield {
+                    'p': Box(),  # good key
+                    'a-b': Box(),  # key can't contain a '-' #147
                 }
 
         with self.assertRaises(ValueError):

--- a/tests/t_cqparts/test_assembly.py
+++ b/tests/t_cqparts/test_assembly.py
@@ -310,10 +310,15 @@ class SearchTests(CQPartsTest):
         self.assertIsInstance(car.find('chassis'), simplecar.Chassis)  # part
         self.assertIsInstance(car.find('front_wheels'), simplecar.AxleAsm)  # assembly
 
-    def test_2nd_layer(self):
+    def test_2nd_layer_period(self):
         car = SimpleCar()
         self.assertIsInstance(car.find('front_wheels.axle'), simplecar.Axle)
         self.assertIsInstance(car.find('front_wheels.wheel_left'), simplecar.Wheel)
+
+    def test_2nd_layer_dash(self):
+        car = SimpleCar()
+        self.assertIsInstance(car.find('front_wheels-axle'), simplecar.Axle)
+        self.assertIsInstance(car.find('front_wheels-wheel_left'), simplecar.Wheel)
 
     def test_bad_paths(self):
         car = SimpleCar()

--- a/tests/t_cqparts/test_codecs.py
+++ b/tests/t_cqparts/test_codecs.py
@@ -339,7 +339,7 @@ class TestGltf(CodecFolderTest):
         self.assertFilesizeNonZero(os.path.join(self.foldername, 'asm.gltf'))
         for name in asm.components.keys():  # only works because it's a single layer assembly
             self.assertFilesizeNonZero(
-                os.path.join(self.foldername, 'asm.%s.bin' % name)
+                os.path.join(self.foldername, 'asm-%s.bin' % name)
             )
 
     def test_tolerance(self):

--- a/tests/t_cqparts/test_codecs.py
+++ b/tests/t_cqparts/test_codecs.py
@@ -23,8 +23,8 @@ class CodecTest(CQPartsTest):
         self.assertEqual(os.stat(filename).st_size, 0)
 
     def assertFilesizeNonZero(self, filename):
-        self.assertTrue(os.path.exists(filename))
-        self.assertGreater(os.stat(filename).st_size, 0)
+        self.assertTrue(os.path.exists(filename), "file does not exist: {!r}".format(filename))
+        self.assertGreater(os.stat(filename).st_size, 0, "file is empty: {!r}".format(filename))
 
     @contextmanager
     def assertCreatesFile(self, filename, nonzero=True):


### PR DESCRIPTION
Threejs removes full stops from object names , change to dash , so the names can be rerefernced from javascript.
